### PR TITLE
 Adding a CMakeLists.txt.in that contains the description for downloa…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,8 +4,48 @@ set(CMAKE_CONFIGURATION_TYPES Debug Release CACHE TYPE INTERNAL FORCE)
 
 project(kifu)
 
+set(LIB_DIR libs)
+set(EIGEN_DOWNLOAD_DIR eigensrc-download)
+set(EIGEN_BUILD_DIR eigensrc-build)
+set(EIGEN_DIR eigen)
+############
+#Technique similiar to a google test setup with automatic download and install
+#Thanks to: https://chromium.googlesource.com/external/github.com/google/googletest/+/HEAD/googletest/README.md
+# Download and unpack eigen at configure time
+if (NOT EXISTS ${CMAKE_BINARY_DIR}/${LIB_DIR}/${EIGEN_DOWNLOAD_DIR}/CMakeLists.txt ) # We assume it's downloaded if CMakeLists.txt is present!
+MESSAGE("Downloading Files from Eigen Git Repo...")
+
+   configure_file(CMakeLists.txt.in ${LIB_DIR}/eigensrc-download/CMakeLists.txt)
+   execute_process(COMMAND ${CMAKE_COMMAND} ${CMAKE_GENERATOR} .
+   WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/${LIB_DIR}/${EIGEN_DOWNLOAD_DIR}
+   )
+
+#setting error_quiet here is arguably a buggy solution. It is not possible with this method otherwise however, as some git files are copied right in the end, that don't exist in the directory anymore. This is not the case for the google test setup however
+execute_process(COMMAND ${CMAKE_COMMAND} --build ${CMAKE_BINARY_DIR}/${LIB_DIR}/${EIGEN_DOWNLOAD_DIR}
+    ERROR_QUIET
+     )
+endif()
+
+#Run CMake on downloaded files and place make files into build dir
+if (NOT EXISTS ${CMAKE_BINARY_DIR}/${LIB_DIR}/${EIGEN_DIR}/include )# We assume it's downloaded if CMakeLists.txt is present!
+MESSAGE("Making and Installing Eigen to Libs...")
+execute_process(COMMAND ${CMAKE_COMMAND}  ${CMAKE_BINARY_DIR}/${LIB_DIR}/${EIGEN_DOWNLOAD_DIR}
+      -DCMAKE_INSTALL_PREFIX=${CMAKE_BINARY_DIR}/${LIB_DIR}/${EIGEN_DIR}
+    WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/${LIB_DIR}/${EIGEN_BUILD_DIR}
+  )
+
+#Call make install on build directory of eig
+execute_process(COMMAND ${CMAKE_COMMAND} --build ${CMAKE_BINARY_DIR}/${LIB_DIR}/${EIGEN_BUILD_DIR} --target install
+       )
+endif()
+#add_subdirectory(${LIB_DIR}
+############
+
 set(LIBRARY_DIR ${CMAKE_CURRENT_SOURCE_DIR} libs CACHE PATH "Path to lib folder")
-set(Eigen3_INCLUDE_DIR ${LIBRARY_DIR}/Eigen/ CACHE PATH "Path to Eigen source folder")
+#set(Eigen3_INCLUDE_DIR ${LIBRARY_DIR}/Eigen/ CACHE PATH "Path to Eigen source folder")
+set(Eigen3_INCLUDE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/../libs/eigen/include/eigen3)
+
+MESSAGE(${CMAKE_BINARY_DIR}/libs/eigen/include/eigen3)
 
 set(CMAKE_CXX_STANDARD 14)
 
@@ -41,6 +81,8 @@ find_package(OpenMP)
 
 link_directories(${FreeImage_LIBRARY_DIR})
 add_executable(kifu ${HEADERS} ${SOURCES})
+
+
 target_include_directories(kifu PUBLIC ${Eigen3_INCLUDE_DIR} ${FreeImage_INCLUDE_DIR} ${Flann_INCLUDE_DIR})
 
 if(OpenMP_CXX_FOUND)

--- a/CMakeLists.txt.in
+++ b/CMakeLists.txt.in
@@ -1,0 +1,14 @@
+cmake_minimum_required(VERSION 3.13)
+project(eigensrc-download NONE)
+
+include(ExternalProject)
+ExternalProject_Add(eigen
+    GIT_REPOSITORY https://github.com/libigl/eigen.git
+    GIT_TAG master
+    SOURCE_DIR "${CMAKE_BINARY_DIR}/${LIB_DIR}/${EIGEN_DOWNLOAD_DIR}"
+    BINARY_DIR "${CMAKE_BINARY_DIR}/${LIB_DIR}/${EIGEN_BUILD_DIR}"
+    #CONFIGURE_COMMAND ""
+    #BUILD_COMMAND ""
+    #INSTALL_COMMAND ""
+)
+


### PR DESCRIPTION
…ding the eigen library from its git repo

 The downloaded CMakeListst.txt file needs to be run by cmake and the makefile built.

 Building the makefile starts a download of the files from the git repo. Unfortunately for this project an error is caused in the end when internal git files for the external project are supposed to be copied.
    As this schema is taken from googletest and no errors are generated there, I suggest some problem with this technique being linked to Eigen. The Errors are suppressed on purpose - even though it is a buggy solution.

This commit makes it more comfortable for new developers to get started.