### PR TITLE
Giving static assert a comment so there is no error

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,7 +68,7 @@ if (NOT EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/${LIB_DIR}/${FLANN_BUILD_DIR}/Makefil
         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/${LIB_DIR}/${FLANN_SOURCE_DIR}
         OUTPUT_VARIABLE output
         )
-    message(${output})
+   # message(${output})
 
     message("call cmake for flann")
     execute_process(COMMAND ${CMAKE_COMMAND} ${CMAKE_CURRENT_SOURCE_DIR}/${LIB_DIR}/${FLANN_SOURCE_DIR}

--- a/ProjectLibrary/utils/BilateralFilter.h
+++ b/ProjectLibrary/utils/BilateralFilter.h
@@ -7,16 +7,16 @@
  * @tparam size The size of size^2 gaussian kernel.
  * @tparam sigma Sigma of gaussian. Type is int because of being a template paramter.
  */
-template <int size, int sigma>
+template<int size, int sigma, typename T = float>
 struct GaussianKernel
 {
     constexpr GaussianKernel()
         : kernel()
     {
-        static_assert(size > 0);
-        static_assert(size % 2 == 1);
-        static_assert(size < 13);
-        static_assert(sigma > 0);
+        static_assert(size > 0, "Size has to be bigger than 0");
+        static_assert(size % 2 == 1, "Size needs to be a multiple of two");
+        static_assert(size < 13, "Size smaller than 14 not allowed"); //because 13 is also not allowed as it is not a multiple of two
+        static_assert(sigma > 0, "Sima needs to be bigger than 0");
 
         int it_r = size/2;
 
@@ -44,7 +44,7 @@ struct GaussianKernel
             el /= sum;
         }
     }
-    std::array<float, size*size> kernel;
+    std::array<T, size*size> kernel;
 };
 
 /**
@@ -101,7 +101,7 @@ private:
             for (int j = -it_s; j <= it_s; ++j)
             {
                 // skip values at the corner (simulates zero-padding)
-                if(x+i < 0 || x+i >= w || y+j < 0 || y+j >= h)
+                if(int(x)+i < 0 || int(x)+i >= w || int(y)+j < 0 || int(y)+j >= h)
                 {
                     //std::cout << "skipping index[" << static_cast<int>(x+i) <<
                     //             " " << static_cast<int>(y+j) << "]" << std::endl;


### PR DESCRIPTION
in function evalKernel: Casting size_t to int, otherwise loop integer is implicitely casted to unsigned! Comparison with <0 not sensible (gave a warning)

Adding a default template parameter to GaussianKernel so it can also be used with double.